### PR TITLE
Ignore and validate file id

### DIFF
--- a/DeviceHub/Properties/Strings.Designer.cs
+++ b/DeviceHub/Properties/Strings.Designer.cs
@@ -88,7 +88,7 @@ namespace Acumatica.DeviceHub.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Queue {0} - print job {1} has no &apos;FILEID&apos; parameter configured..
+        ///   Looks up a localized string similar to Queue {0} - print job {1} has no &apos;FILEID&apos; parameter configured. The print job will be discarded..
         /// </summary>
         internal static string FileIdMissingWarning {
             get {

--- a/DeviceHub/Properties/Strings.Designer.cs
+++ b/DeviceHub/Properties/Strings.Designer.cs
@@ -88,6 +88,15 @@ namespace Acumatica.DeviceHub.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Queue {0} - print job {1} has no &apos;FILEID&apos; parameter configured..
+        /// </summary>
+        internal static string FileIdMissingWarning {
+            get {
+                return ResourceManager.GetString("FileIdMissingWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Please enter your login..
         /// </summary>
         internal static string LoginMissingPrompt {

--- a/DeviceHub/Properties/Strings.resx
+++ b/DeviceHub/Properties/Strings.resx
@@ -127,7 +127,7 @@
     <value>Queue is empty.</value>
   </data>
   <data name="FileIdMissingWarning" xml:space="preserve">
-    <value>Queue {0} - print job {1} has no 'FILEID' parameter configured.</value>
+    <value>Queue {0} - print job {1} has no 'FILEID' parameter configured. The print job will be discarded.</value>
   </data>
   <data name="LoginMissingPrompt" xml:space="preserve">
     <value>Please enter your login.</value>

--- a/DeviceHub/Properties/Strings.resx
+++ b/DeviceHub/Properties/Strings.resx
@@ -126,6 +126,9 @@
   <data name="EmptyQueueNotify" xml:space="preserve">
     <value>Queue is empty.</value>
   </data>
+  <data name="FileIdMissingWarning" xml:space="preserve">
+    <value>Queue {0} - print job {1} has no 'FILEID' parameter configured.</value>
+  </data>
   <data name="LoginMissingPrompt" xml:space="preserve">
     <value>Please enter your login.</value>
   </data>

--- a/PX.Objects.WM/Descriptor/Messages.cs
+++ b/PX.Objects.WM/Descriptor/Messages.cs
@@ -11,6 +11,8 @@ namespace PX.Objects.WM
         public const string Remove = "Remove";
         public const string Weight = "Weight";
 
+        public const string MissingFileIdError = "Print job has no 'Report ID' or 'FILEID' parameter defined.";
+        
         #region Barcode
         public const string BarcodeMissing = "Barcode {0} not found in database.";
         public const string BarcodePrompt = "Please scan a barcode.";

--- a/PX.Objects.WM/Pages/SO302010.aspx
+++ b/PX.Objects.WM/Pages/SO302010.aspx
@@ -49,7 +49,7 @@
 	</px:PXDataSource>
 </asp:content>
 <asp:content id="cont2" contentplaceholderid="phF" runat="Server">
-	<px:PXFormView ID="form" runat="server" DataSourceID="ds" Height="63px" Width="100%" Visible="true" DataMember="Document" DefaultControlID="edShipmentNbr">
+	<px:PXFormView ID="form" runat="server" DataSourceID="ds" Height="100px" Width="100%" Visible="true" DataMember="Document" DefaultControlID="edShipmentNbr">
         <Template>
             <px:PXLayoutRule runat="server" StartColumn="True" LabelsWidth="S" ControlSize="L" />
 			<px:PXSelector ID="edShipmentNbr" runat="server" DataField="ShipmentNbr" AutoRefresh="true" AllowEdit="true" CommitChanges="true" AutoComplete="false" />

--- a/PX.Objects.WM/PrintJobMaint.cs
+++ b/PX.Objects.WM/PrintJobMaint.cs
@@ -8,5 +8,27 @@ namespace PX.SM
     {
         public PXSelect<SMPrintJob> Job;
         public PXSelect<SMPrintJobParameter, Where<SMPrintJobParameter.jobID, Equal<Current<SMPrintJob.jobID>>>> Parameters;
+
+        public virtual void SMPrintJob_RowPersisting(PXCache sender, PXRowPersistingEventArgs e)
+        {
+            const string fileIdParameter = "FILEID";
+            bool isFileId = false;
+            SMPrintJob smPrintJob = e.Row as SMPrintJob;
+            
+            if (smPrintJob != null && String.IsNullOrWhiteSpace(smPrintJob.ReportID))
+            {
+                foreach (SMPrintJobParameter smPrintJobParameter in Parameters.Select())
+                {
+                    if (smPrintJobParameter.ParameterName.Trim().ToUpperInvariant().Equals(fileIdParameter))
+                    {
+                        isFileId = true;
+                        break;
+                    }
+                }
+
+                if (!isFileId)
+                    throw new PXRowPersistingException(typeof(SMPrintJob.reportID).Name, null, Objects.WM.Messages.MissingFileIdError);
+            }
+        }
     }
 }


### PR DESCRIPTION
Validate and ignore invalid print jobs (scenario where you have missing FileId - should just be discarded instead of throwing exception).