### PR TITLE
Fix error occuring after record insertion

### DIFF
--- a/PX.Objects.WM/PickPackShip.cs
+++ b/PX.Objects.WM/PickPackShip.cs
@@ -865,8 +865,10 @@ namespace PX.Objects.SO
         {
             if (UserSetup.AskExt() == WebDialogResult.OK)
             {
-                Caches[typeof(SOPickPackShipUserSetup)].Persist(PXDBOperation.Insert);
-                Caches[typeof(SOPickPackShipUserSetup)].Persist(PXDBOperation.Update);
+                PXCache cache = Caches[typeof(SOPickPackShipUserSetup)];
+                cache.Persist(PXDBOperation.Insert);
+                cache.Persist(PXDBOperation.Update);
+                cache.Clear();
             }
         }
 


### PR DESCRIPTION
Need to clear DAC cache after insertion to ensure the inserted record is reloaded on next roundtrip to the server.