### PR TITLE
Add user role security on confirm, confirm all, set quantity commands

### DIFF
--- a/PX.Objects.WM/Descriptor/Messages.cs
+++ b/PX.Objects.WM/Descriptor/Messages.cs
@@ -31,6 +31,7 @@ namespace PX.Objects.WM
         public const string CommandRemove = "Remove mode set.";
         public const string CommandUnknown = "Unknown command.";
         public const string CommandSetQuantity = "Quantity set to {0}.";
+        public const string CommandAccessRightsError = "Insufficient access rights to perform this command.";
         #endregion
 
         #region Lot/Serial

--- a/PX.Objects.WM/PickPackShip.cs
+++ b/PX.Objects.WM/PickPackShip.cs
@@ -246,9 +246,12 @@ namespace PX.Objects.SO
             int quantity = 0;
             if(int.TryParse(commands[1], out quantity))
             {
-                doc.Quantity = quantity;
-                doc.Status = ScanStatuses.Information;
-                doc.Message = PXMessages.LocalizeFormatNoPrefix(WM.Messages.CommandSetQuantity, quantity);
+                if (IsQuantityEnabled())
+                {
+                    doc.Quantity = quantity;
+                    doc.Status = ScanStatuses.Information;
+                    doc.Message = PXMessages.LocalizeFormatNoPrefix(WM.Messages.CommandSetQuantity, quantity);
+                }
 
                 if(commands.Length > 2)
                 {
@@ -280,10 +283,16 @@ namespace PX.Objects.SO
                         doc.Message = WM.Messages.CommandLot;
                         break;
                     case ScanCommands.Confirm:
-                        this.Confirm.Press();
+                        if (Confirm.GetEnabled())
+                        {
+                            this.Confirm.Press();
+                        }
                         break;
                     case ScanCommands.ConfirmAll:
-                        this.ConfirmAll.Press();
+                        if (ConfirmAll.GetEnabled())
+                        {
+                            this.ConfirmAll.Press();
+                        }
                         break;
                     case ScanCommands.Clear:
                         ClearScreen();
@@ -939,6 +948,15 @@ namespace PX.Objects.SO
                     return true;
                 }
             }
+
+            return false;
+        }
+
+        protected virtual bool IsQuantityEnabled()
+        {
+            foreach (PXEventSubscriberAttribute attribute in Document.Cache.GetAttributesReadonly<PickPackInfo.quantity>())
+                if (attribute is PXUIFieldAttribute)
+                    return ((PXUIFieldAttribute)attribute).Enabled;
 
             return false;
         }

--- a/PX.Objects.WM/PickPackShip.cs
+++ b/PX.Objects.WM/PickPackShip.cs
@@ -251,11 +251,15 @@ namespace PX.Objects.SO
                     doc.Quantity = quantity;
                     doc.Status = ScanStatuses.Information;
                     doc.Message = PXMessages.LocalizeFormatNoPrefix(WM.Messages.CommandSetQuantity, quantity);
-                }
 
-                if(commands.Length > 2)
+                    if (commands.Length > 2)
+                    {
+                        ProcessBarcode(commands[2]);
+                    }
+                }
+                else
                 {
-                    ProcessBarcode(commands[2]);
+                    throw new PXException(WM.Messages.CommandAccessRightsError);
                 }
             }
             else
@@ -287,11 +291,19 @@ namespace PX.Objects.SO
                         {
                             this.Confirm.Press();
                         }
+                        else
+                        {
+                            throw new PXException(WM.Messages.CommandAccessRightsError);
+                        }
                         break;
                     case ScanCommands.ConfirmAll:
                         if (ConfirmAll.GetEnabled())
                         {
                             this.ConfirmAll.Press();
+                        }
+                        else
+                        {
+                            throw new PXException(WM.Messages.CommandAccessRightsError);
                         }
                         break;
                     case ScanCommands.Clear:


### PR DESCRIPTION
Take into account user role screen security on confirm, confirm all and set quantity commands base on PXFUIFieldAttribute and action enabled.