### PR TITLE
Pro pharma bug fixes

### DIFF
--- a/Customization/Pages/SO/SO302010.aspx
+++ b/Customization/Pages/SO/SO302010.aspx
@@ -191,7 +191,7 @@
 						<Levels>
 							<px:PXGridLevel DataMember="ScanLogs">
 								<Columns>
-									<px:PXGridColumn DataField="LogLineDate" Width="100px" />
+									<px:PXGridColumn DataField="LogLineDate" Width="160px" />
 									<px:PXGridColumn DataField="LogBarcode" Width="200px" />
 									<px:PXGridColumn DataField="LogMessage" Width="400px" />
 								</Columns>

--- a/DeviceHub/Configuration.Designer.cs
+++ b/DeviceHub/Configuration.Designer.cs
@@ -61,6 +61,7 @@
             this.acumaticaScaleIDTextBox = new System.Windows.Forms.TextBox();
             this.label7 = new System.Windows.Forms.Label();
             this.scalesDropDown = new System.Windows.Forms.ComboBox();
+            this.showAllDevicesCheckBox = new System.Windows.Forms.CheckBox();
             this.mainTab.SuspendLayout();
             this.tabPage1.SuspendLayout();
             this.tabPage2.SuspendLayout();
@@ -274,6 +275,7 @@
             // 
             // tabPage3
             // 
+            this.tabPage3.Controls.Add(this.showAllDevicesCheckBox);
             this.tabPage3.Controls.Add(this.label8);
             this.tabPage3.Controls.Add(this.acumaticaScaleIDTextBox);
             this.tabPage3.Controls.Add(this.label7);
@@ -303,6 +305,13 @@
             this.scalesDropDown.FormattingEnabled = true;
             resources.ApplyResources(this.scalesDropDown, "scalesDropDown");
             this.scalesDropDown.Name = "scalesDropDown";
+            // 
+            // showAllDevicesCheckBox
+            // 
+            resources.ApplyResources(this.showAllDevicesCheckBox, "showAllDevicesCheckBox");
+            this.showAllDevicesCheckBox.Name = "showAllDevicesCheckBox";
+            this.showAllDevicesCheckBox.UseVisualStyleBackColor = true;
+            this.showAllDevicesCheckBox.CheckedChanged += new System.EventHandler(this.showAllDevicesCheckBox_CheckedChanged);
             // 
             // Configuration
             // 
@@ -363,5 +372,6 @@
         private System.Windows.Forms.TextBox acumaticaScaleIDTextBox;
         private System.Windows.Forms.Label label7;
         private System.Windows.Forms.ComboBox scalesDropDown;
+        private System.Windows.Forms.CheckBox showAllDevicesCheckBox;
     }
 }

--- a/DeviceHub/Configuration.resx
+++ b/DeviceHub/Configuration.resx
@@ -119,10 +119,14 @@
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="okButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>352, 297</value>
+    <value>528, 457</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="okButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="okButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>112, 35</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="okButton.TabIndex" type="System.Int32, mscorlib">
@@ -144,10 +148,13 @@
     <value>2</value>
   </data>
   <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>433, 297</value>
+    <value>650, 457</value>
+  </data>
+  <data name="cancelButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="cancelButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>112, 35</value>
   </data>
   <data name="cancelButton.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -167,14 +174,497 @@
   <data name="&gt;&gt;cancelButton.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="&gt;&gt;label5.Name" xml:space="preserve">
+    <value>label5</value>
+  </data>
+  <data name="&gt;&gt;label5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
+    <value>tabPage1</value>
+  </data>
+  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;label4.Name" xml:space="preserve">
+    <value>label4</value>
+  </data>
+  <data name="&gt;&gt;label4.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
+    <value>tabPage1</value>
+  </data>
+  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;passwordTextBox.Name" xml:space="preserve">
+    <value>passwordTextBox</value>
+  </data>
+  <data name="&gt;&gt;passwordTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;passwordTextBox.Parent" xml:space="preserve">
+    <value>tabPage1</value>
+  </data>
+  <data name="&gt;&gt;passwordTextBox.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;loginTextBox.Name" xml:space="preserve">
+    <value>loginTextBox</value>
+  </data>
+  <data name="&gt;&gt;loginTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;loginTextBox.Parent" xml:space="preserve">
+    <value>tabPage1</value>
+  </data>
+  <data name="&gt;&gt;loginTextBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>tabPage1</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;acumaticaUrlTextBox.Name" xml:space="preserve">
+    <value>acumaticaUrlTextBox</value>
+  </data>
+  <data name="&gt;&gt;acumaticaUrlTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;acumaticaUrlTextBox.Parent" xml:space="preserve">
+    <value>tabPage1</value>
+  </data>
+  <data name="&gt;&gt;acumaticaUrlTextBox.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="tabPage1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 29</value>
+  </data>
+  <data name="tabPage1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="tabPage1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="tabPage1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>752, 421</value>
+  </data>
+  <data name="tabPage1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="tabPage1.Text" xml:space="preserve">
+    <value>Site</value>
+  </data>
+  <data name="&gt;&gt;tabPage1.Name" xml:space="preserve">
+    <value>tabPage1</value>
+  </data>
+  <data name="&gt;&gt;tabPage1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tabPage1.Parent" xml:space="preserve">
+    <value>mainTab</value>
+  </data>
+  <data name="&gt;&gt;tabPage1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;rawModeCheckbox.Name" xml:space="preserve">
+    <value>rawModeCheckbox</value>
+  </data>
+  <data name="&gt;&gt;rawModeCheckbox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rawModeCheckbox.Parent" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;rawModeCheckbox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;label9.Name" xml:space="preserve">
+    <value>label9</value>
+  </data>
+  <data name="&gt;&gt;label9.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label9.Parent" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;label9.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;label6.Name" xml:space="preserve">
+    <value>label6</value>
+  </data>
+  <data name="&gt;&gt;label6.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label6.Parent" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;paperSourceCombo.Name" xml:space="preserve">
+    <value>paperSourceCombo</value>
+  </data>
+  <data name="&gt;&gt;paperSourceCombo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;paperSourceCombo.Parent" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;paperSourceCombo.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;orientationGroupBox.Name" xml:space="preserve">
+    <value>orientationGroupBox</value>
+  </data>
+  <data name="&gt;&gt;orientationGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;orientationGroupBox.Parent" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;orientationGroupBox.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;paperSizeCombo.Name" xml:space="preserve">
+    <value>paperSizeCombo</value>
+  </data>
+  <data name="&gt;&gt;paperSizeCombo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;paperSizeCombo.Parent" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;paperSizeCombo.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;label3.Name" xml:space="preserve">
+    <value>label3</value>
+  </data>
+  <data name="&gt;&gt;label3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;printerCombo.Name" xml:space="preserve">
+    <value>printerCombo</value>
+  </data>
+  <data name="&gt;&gt;printerCombo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;printerCombo.Parent" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;printerCombo.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;label2.Name" xml:space="preserve">
+    <value>label2</value>
+  </data>
+  <data name="&gt;&gt;label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;queueName.Name" xml:space="preserve">
+    <value>queueName</value>
+  </data>
+  <data name="&gt;&gt;queueName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;queueName.Parent" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;queueName.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;removePrintQueue.Name" xml:space="preserve">
+    <value>removePrintQueue</value>
+  </data>
+  <data name="&gt;&gt;removePrintQueue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;removePrintQueue.Parent" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;removePrintQueue.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;addPrintQueue.Name" xml:space="preserve">
+    <value>addPrintQueue</value>
+  </data>
+  <data name="&gt;&gt;addPrintQueue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;addPrintQueue.Parent" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;addPrintQueue.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;queueList.Name" xml:space="preserve">
+    <value>queueList</value>
+  </data>
+  <data name="&gt;&gt;queueList.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;queueList.Parent" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;queueList.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="tabPage2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 29</value>
+  </data>
+  <data name="tabPage2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="tabPage2.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="tabPage2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>752, 421</value>
+  </data>
+  <data name="tabPage2.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tabPage2.Text" xml:space="preserve">
+    <value>Print Queues</value>
+  </data>
+  <data name="&gt;&gt;tabPage2.Name" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;tabPage2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tabPage2.Parent" xml:space="preserve">
+    <value>mainTab</value>
+  </data>
+  <data name="&gt;&gt;tabPage2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="showAllDevicesCheckBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="showAllDevicesCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>116, 95</value>
+  </data>
+  <data name="showAllDevicesCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>151, 24</value>
+  </data>
+  <data name="showAllDevicesCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="showAllDevicesCheckBox.Text" xml:space="preserve">
+    <value>Show all devices</value>
+  </data>
+  <data name="&gt;&gt;showAllDevicesCheckBox.Name" xml:space="preserve">
+    <value>showAllDevicesCheckBox</value>
+  </data>
+  <data name="&gt;&gt;showAllDevicesCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;showAllDevicesCheckBox.Parent" xml:space="preserve">
+    <value>tabPage3</value>
+  </data>
+  <data name="&gt;&gt;showAllDevicesCheckBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="label8.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label8.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 14</value>
+  </data>
+  <data name="label8.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
+  </data>
+  <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
+    <value>74, 20</value>
+  </data>
+  <data name="label8.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="label8.Text" xml:space="preserve">
+    <value>Scale ID:</value>
+  </data>
+  <data name="&gt;&gt;label8.Name" xml:space="preserve">
+    <value>label8</value>
+  </data>
+  <data name="&gt;&gt;label8.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label8.Parent" xml:space="preserve">
+    <value>tabPage3</value>
+  </data>
+  <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="acumaticaScaleIDTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>116, 9</value>
+  </data>
+  <data name="acumaticaScaleIDTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="acumaticaScaleIDTextBox.MaxLength" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="acumaticaScaleIDTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>232, 26</value>
+  </data>
+  <data name="acumaticaScaleIDTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;acumaticaScaleIDTextBox.Name" xml:space="preserve">
+    <value>acumaticaScaleIDTextBox</value>
+  </data>
+  <data name="&gt;&gt;acumaticaScaleIDTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;acumaticaScaleIDTextBox.Parent" xml:space="preserve">
+    <value>tabPage3</value>
+  </data>
+  <data name="&gt;&gt;acumaticaScaleIDTextBox.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="label7.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 54</value>
+  </data>
+  <data name="label7.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
+  </data>
+  <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
+    <value>61, 20</value>
+  </data>
+  <data name="label7.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="label7.Text" xml:space="preserve">
+    <value>Device:</value>
+  </data>
+  <data name="&gt;&gt;label7.Name" xml:space="preserve">
+    <value>label7</value>
+  </data>
+  <data name="&gt;&gt;label7.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label7.Parent" xml:space="preserve">
+    <value>tabPage3</value>
+  </data>
+  <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="scalesDropDown.Location" type="System.Drawing.Point, System.Drawing">
+    <value>116, 49</value>
+  </data>
+  <data name="scalesDropDown.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="scalesDropDown.Size" type="System.Drawing.Size, System.Drawing">
+    <value>462, 28</value>
+  </data>
+  <data name="scalesDropDown.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;scalesDropDown.Name" xml:space="preserve">
+    <value>scalesDropDown</value>
+  </data>
+  <data name="&gt;&gt;scalesDropDown.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;scalesDropDown.Parent" xml:space="preserve">
+    <value>tabPage3</value>
+  </data>
+  <data name="&gt;&gt;scalesDropDown.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="tabPage3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 29</value>
+  </data>
+  <data name="tabPage3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="tabPage3.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="tabPage3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>752, 421</value>
+  </data>
+  <data name="tabPage3.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tabPage3.Text" xml:space="preserve">
+    <value>Digital Scale</value>
+  </data>
+  <data name="&gt;&gt;tabPage3.Name" xml:space="preserve">
+    <value>tabPage3</value>
+  </data>
+  <data name="&gt;&gt;tabPage3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tabPage3.Parent" xml:space="preserve">
+    <value>mainTab</value>
+  </data>
+  <data name="&gt;&gt;tabPage3.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="mainTab.Location" type="System.Drawing.Point, System.Drawing">
+    <value>2, 2</value>
+  </data>
+  <data name="mainTab.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="mainTab.Size" type="System.Drawing.Size, System.Drawing">
+    <value>760, 454</value>
+  </data>
+  <data name="mainTab.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;mainTab.Name" xml:space="preserve">
+    <value>mainTab</value>
+  </data>
+  <data name="&gt;&gt;mainTab.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;mainTab.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mainTab.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 61</value>
+    <value>16, 94</value>
+  </data>
+  <data name="label5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>82, 20</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -198,10 +688,13 @@
     <value>True</value>
   </data>
   <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 35</value>
+    <value>16, 54</value>
+  </data>
+  <data name="label4.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>36, 13</value>
+    <value>52, 20</value>
   </data>
   <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -222,13 +715,16 @@
     <value>1</value>
   </data>
   <data name="passwordTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 58</value>
+    <value>102, 89</value>
+  </data>
+  <data name="passwordTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="passwordTextBox.PasswordChar" type="System.Char, mscorlib" xml:space="preserve">
     <value>*</value>
   </data>
   <data name="passwordTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>126, 20</value>
+    <value>187, 26</value>
   </data>
   <data name="passwordTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -246,10 +742,13 @@
     <value>2</value>
   </data>
   <data name="loginTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 32</value>
+    <value>102, 49</value>
+  </data>
+  <data name="loginTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="loginTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>126, 20</value>
+    <value>187, 26</value>
   </data>
   <data name="loginTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -270,10 +769,13 @@
     <value>True</value>
   </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 9</value>
+    <value>16, 14</value>
+  </data>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 13</value>
+    <value>46, 20</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -294,13 +796,16 @@
     <value>4</value>
   </data>
   <data name="acumaticaUrlTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>68, 6</value>
+    <value>102, 9</value>
+  </data>
+  <data name="acumaticaUrlTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="acumaticaUrlTextBox.MaxLength" type="System.Int32, mscorlib">
     <value>3200</value>
   </data>
   <data name="acumaticaUrlTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>309, 20</value>
+    <value>462, 26</value>
   </data>
   <data name="acumaticaUrlTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -317,42 +822,17 @@
   <data name="&gt;&gt;acumaticaUrlTextBox.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="tabPage1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="tabPage1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tabPage1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>499, 269</value>
-  </data>
-  <data name="tabPage1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tabPage1.Text" xml:space="preserve">
-    <value>Site</value>
-  </data>
-  <data name="&gt;&gt;tabPage1.Name" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;tabPage1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabPage1.Parent" xml:space="preserve">
-    <value>mainTab</value>
-  </data>
-  <data name="&gt;&gt;tabPage1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="rawModeCheckbox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="rawModeCheckbox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>182, 63</value>
+    <value>273, 97</value>
+  </data>
+  <data name="rawModeCheckbox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="rawModeCheckbox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>257, 17</value>
+    <value>381, 24</value>
   </data>
   <data name="rawModeCheckbox.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -376,10 +856,13 @@
     <value>True</value>
   </data>
   <data name="label9.Location" type="System.Drawing.Point, System.Drawing">
-    <value>115, 114</value>
+    <value>172, 175</value>
+  </data>
+  <data name="label9.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>82, 20</value>
   </data>
   <data name="label9.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -403,10 +886,13 @@
     <value>True</value>
   </data>
   <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>115, 87</value>
+    <value>172, 134</value>
+  </data>
+  <data name="label6.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 13</value>
+    <value>90, 20</value>
   </data>
   <data name="label6.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -427,10 +913,13 @@
     <value>2</value>
   </data>
   <data name="paperSourceCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>182, 111</value>
+    <value>273, 171</value>
+  </data>
+  <data name="paperSourceCombo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="paperSourceCombo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>156, 21</value>
+    <value>232, 28</value>
   </data>
   <data name="paperSourceCombo.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -447,14 +936,83 @@
   <data name="&gt;&gt;paperSourceCombo.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="&gt;&gt;orientationLandscape.Name" xml:space="preserve">
+    <value>orientationLandscape</value>
+  </data>
+  <data name="&gt;&gt;orientationLandscape.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;orientationLandscape.Parent" xml:space="preserve">
+    <value>orientationGroupBox</value>
+  </data>
+  <data name="&gt;&gt;orientationLandscape.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;orientationPortrait.Name" xml:space="preserve">
+    <value>orientationPortrait</value>
+  </data>
+  <data name="&gt;&gt;orientationPortrait.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;orientationPortrait.Parent" xml:space="preserve">
+    <value>orientationGroupBox</value>
+  </data>
+  <data name="&gt;&gt;orientationPortrait.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;orientationAutomatic.Name" xml:space="preserve">
+    <value>orientationAutomatic</value>
+  </data>
+  <data name="&gt;&gt;orientationAutomatic.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;orientationAutomatic.Parent" xml:space="preserve">
+    <value>orientationGroupBox</value>
+  </data>
+  <data name="&gt;&gt;orientationAutomatic.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="orientationGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>177, 212</value>
+  </data>
+  <data name="orientationGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="orientationGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="orientationGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>330, 135</value>
+  </data>
+  <data name="orientationGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="orientationGroupBox.Text" xml:space="preserve">
+    <value>Orientation</value>
+  </data>
+  <data name="&gt;&gt;orientationGroupBox.Name" xml:space="preserve">
+    <value>orientationGroupBox</value>
+  </data>
+  <data name="&gt;&gt;orientationGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;orientationGroupBox.Parent" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;orientationGroupBox.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
   <data name="orientationLandscape.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="orientationLandscape.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 65</value>
+    <value>9, 100</value>
+  </data>
+  <data name="orientationLandscape.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="orientationLandscape.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 17</value>
+    <value>113, 24</value>
   </data>
   <data name="orientationLandscape.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -478,10 +1036,13 @@
     <value>True</value>
   </data>
   <data name="orientationPortrait.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 42</value>
+    <value>9, 65</value>
+  </data>
+  <data name="orientationPortrait.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="orientationPortrait.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 17</value>
+    <value>85, 24</value>
   </data>
   <data name="orientationPortrait.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -505,10 +1066,13 @@
     <value>True</value>
   </data>
   <data name="orientationAutomatic.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 19</value>
+    <value>9, 29</value>
+  </data>
+  <data name="orientationAutomatic.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="orientationAutomatic.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 17</value>
+    <value>106, 24</value>
   </data>
   <data name="orientationAutomatic.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -528,35 +1092,14 @@
   <data name="&gt;&gt;orientationAutomatic.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="orientationGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>118, 138</value>
-  </data>
-  <data name="orientationGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>220, 88</value>
-  </data>
-  <data name="orientationGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="orientationGroupBox.Text" xml:space="preserve">
-    <value>Orientation</value>
-  </data>
-  <data name="&gt;&gt;orientationGroupBox.Name" xml:space="preserve">
-    <value>orientationGroupBox</value>
-  </data>
-  <data name="&gt;&gt;orientationGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;orientationGroupBox.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;orientationGroupBox.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="paperSizeCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>182, 84</value>
+    <value>273, 129</value>
+  </data>
+  <data name="paperSizeCombo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="paperSizeCombo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>156, 21</value>
+    <value>232, 28</value>
   </data>
   <data name="paperSizeCombo.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -577,10 +1120,13 @@
     <value>True</value>
   </data>
   <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>115, 39</value>
+    <value>172, 60</value>
+  </data>
+  <data name="label3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 13</value>
+    <value>59, 20</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -601,10 +1147,13 @@
     <value>6</value>
   </data>
   <data name="printerCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>182, 36</value>
+    <value>273, 55</value>
+  </data>
+  <data name="printerCombo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="printerCombo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>309, 21</value>
+    <value>462, 28</value>
   </data>
   <data name="printerCombo.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -625,10 +1174,13 @@
     <value>True</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>115, 13</value>
+    <value>172, 20</value>
+  </data>
+  <data name="label2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>38, 13</value>
+    <value>55, 20</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -649,13 +1201,16 @@
     <value>8</value>
   </data>
   <data name="queueName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>182, 10</value>
+    <value>273, 15</value>
+  </data>
+  <data name="queueName.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="queueName.MaxLength" type="System.Int32, mscorlib">
     <value>10</value>
   </data>
   <data name="queueName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>156, 20</value>
+    <value>232, 26</value>
   </data>
   <data name="queueName.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -673,10 +1228,13 @@
     <value>9</value>
   </data>
   <data name="removePrintQueue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 239</value>
+    <value>9, 368</value>
+  </data>
+  <data name="removePrintQueue.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="removePrintQueue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 23</value>
+    <value>147, 35</value>
   </data>
   <data name="removePrintQueue.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -697,10 +1255,13 @@
     <value>10</value>
   </data>
   <data name="addPrintQueue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 210</value>
+    <value>9, 323</value>
+  </data>
+  <data name="addPrintQueue.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="addPrintQueue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 23</value>
+    <value>147, 35</value>
   </data>
   <data name="addPrintQueue.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -720,11 +1281,17 @@
   <data name="&gt;&gt;addPrintQueue.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
+  <data name="queueList.ItemHeight" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
   <data name="queueList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 6</value>
+    <value>9, 9</value>
+  </data>
+  <data name="queueList.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="queueList.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 199</value>
+    <value>145, 304</value>
   </data>
   <data name="queueList.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -741,188 +1308,14 @@
   <data name="&gt;&gt;queueList.ZOrder" xml:space="preserve">
     <value>12</value>
   </data>
-  <data name="tabPage2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tabPage2.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tabPage2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>499, 269</value>
-  </data>
-  <data name="tabPage2.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tabPage2.Text" xml:space="preserve">
-    <value>Print Queues</value>
-  </data>
-  <data name="&gt;&gt;tabPage2.Name" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;tabPage2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabPage2.Parent" xml:space="preserve">
-    <value>mainTab</value>
-  </data>
-  <data name="&gt;&gt;tabPage2.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="label8.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label8.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 9</value>
-  </data>
-  <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 13</value>
-  </data>
-  <data name="label8.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="label8.Text" xml:space="preserve">
-    <value>Scale ID:</value>
-  </data>
-  <data name="&gt;&gt;label8.Name" xml:space="preserve">
-    <value>label8</value>
-  </data>
-  <data name="&gt;&gt;label8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label8.Parent" xml:space="preserve">
-    <value>tabPage3</value>
-  </data>
-  <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="acumaticaScaleIDTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>77, 6</value>
-  </data>
-  <data name="acumaticaScaleIDTextBox.MaxLength" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="acumaticaScaleIDTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>156, 20</value>
-  </data>
-  <data name="acumaticaScaleIDTextBox.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;acumaticaScaleIDTextBox.Name" xml:space="preserve">
-    <value>acumaticaScaleIDTextBox</value>
-  </data>
-  <data name="&gt;&gt;acumaticaScaleIDTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;acumaticaScaleIDTextBox.Parent" xml:space="preserve">
-    <value>tabPage3</value>
-  </data>
-  <data name="&gt;&gt;acumaticaScaleIDTextBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="label7.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 35</value>
-  </data>
-  <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 13</value>
-  </data>
-  <data name="label7.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="label7.Text" xml:space="preserve">
-    <value>Device:</value>
-  </data>
-  <data name="&gt;&gt;label7.Name" xml:space="preserve">
-    <value>label7</value>
-  </data>
-  <data name="&gt;&gt;label7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label7.Parent" xml:space="preserve">
-    <value>tabPage3</value>
-  </data>
-  <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="scalesDropDown.Location" type="System.Drawing.Point, System.Drawing">
-    <value>77, 32</value>
-  </data>
-  <data name="scalesDropDown.Size" type="System.Drawing.Size, System.Drawing">
-    <value>309, 21</value>
-  </data>
-  <data name="scalesDropDown.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;scalesDropDown.Name" xml:space="preserve">
-    <value>scalesDropDown</value>
-  </data>
-  <data name="&gt;&gt;scalesDropDown.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;scalesDropDown.Parent" xml:space="preserve">
-    <value>tabPage3</value>
-  </data>
-  <data name="&gt;&gt;scalesDropDown.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="tabPage3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tabPage3.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tabPage3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>499, 269</value>
-  </data>
-  <data name="tabPage3.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="tabPage3.Text" xml:space="preserve">
-    <value>Digital Scale</value>
-  </data>
-  <data name="&gt;&gt;tabPage3.Name" xml:space="preserve">
-    <value>tabPage3</value>
-  </data>
-  <data name="&gt;&gt;tabPage3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabPage3.Parent" xml:space="preserve">
-    <value>mainTab</value>
-  </data>
-  <data name="&gt;&gt;tabPage3.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="mainTab.Location" type="System.Drawing.Point, System.Drawing">
-    <value>1, 1</value>
-  </data>
-  <data name="mainTab.Size" type="System.Drawing.Size, System.Drawing">
-    <value>507, 295</value>
-  </data>
-  <data name="mainTab.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;mainTab.Name" xml:space="preserve">
-    <value>mainTab</value>
-  </data>
-  <data name="&gt;&gt;mainTab.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;mainTab.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mainTab.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+    <value>9, 20</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>508, 325</value>
+    <value>762, 500</value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -1018,6 +1411,9 @@
         /wH///8B////Af///wH///8B////Af///wEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 </value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>

--- a/DeviceHub/Monitors/ScaleMonitor.cs
+++ b/DeviceHub/Monitors/ScaleMonitor.cs
@@ -111,7 +111,8 @@ namespace Acumatica.DeviceHub
                             break;
                         }
 
-                        decimal currentWeight = 0;
+                        decimal currentWeight = 0m;
+                        decimal readWeight = 0m;
                         WeightUnits weightUnit;
                         HidDevice hidDevice = HidDevices.Enumerate(Properties.Settings.Default.ScaleDeviceVendorId, Properties.Settings.Default.ScaleDeviceProductId).FirstOrDefault();
 
@@ -121,18 +122,22 @@ namespace Acumatica.DeviceHub
                             {
                                 hidDevice.OpenDevice();
                                 WaitForConnection(hidDevice);
-                                currentWeight = ReadWeight(hidDevice, out weightUnit);
+                                readWeight = ReadWeight(hidDevice, out weightUnit);
                                 hidDevice.CloseDevice();
                             }
 
-                            _progress.Report(new MonitorMessage(String.Format(Strings.ScaleWeightNotify, currentWeight, WeightUnitToStringAbbreviation[weightUnit])));
-
-                            if (_lastWeightSentToAcumatica != currentWeight)
+                            if (!weightUnit.Equals(WeightUnits.None))
                             {
-                                if (_screen != null || LoginToAcumatica())
+                                currentWeight = readWeight;
+                                _progress.Report(new MonitorMessage(String.Format(Strings.ScaleWeightNotify, currentWeight, WeightUnitToStringAbbreviation[weightUnit])));
+
+                                if (_lastWeightSentToAcumatica != currentWeight)
                                 {
-                                    UpdateWeight(Properties.Settings.Default.ScaleID, ConvertWeightToKilogram(currentWeight, weightUnit));
-                                    _lastWeightSentToAcumatica = currentWeight;
+                                    if (_screen != null || LoginToAcumatica())
+                                    {
+                                        UpdateWeight(Properties.Settings.Default.ScaleID, ConvertWeightToKilogram(currentWeight, weightUnit));
+                                        _lastWeightSentToAcumatica = currentWeight;
+                                    }
                                 }
                             }
                         }

--- a/DeviceHub/Monitors/ScaleMonitor.cs
+++ b/DeviceHub/Monitors/ScaleMonitor.cs
@@ -110,10 +110,9 @@ namespace Acumatica.DeviceHub
                             LogoutFromAcumatica();
                             break;
                         }
-
-                        decimal currentWeight = 0m;
+                        
                         decimal readWeight = 0m;
-                        WeightUnits weightUnit;
+                        WeightUnits weightUnit = WeightUnits.None;
                         HidDevice hidDevice = HidDevices.Enumerate(Properties.Settings.Default.ScaleDeviceVendorId, Properties.Settings.Default.ScaleDeviceProductId).FirstOrDefault();
 
                         if (hidDevice != null)
@@ -128,15 +127,14 @@ namespace Acumatica.DeviceHub
 
                             if (!weightUnit.Equals(WeightUnits.None))
                             {
-                                currentWeight = readWeight;
-                                _progress.Report(new MonitorMessage(String.Format(Strings.ScaleWeightNotify, currentWeight, WeightUnitToStringAbbreviation[weightUnit])));
+                                _progress.Report(new MonitorMessage(String.Format(Strings.ScaleWeightNotify, readWeight, WeightUnitToStringAbbreviation[weightUnit])));
 
-                                if (_lastWeightSentToAcumatica != currentWeight)
+                                if (_lastWeightSentToAcumatica != readWeight)
                                 {
                                     if (_screen != null || LoginToAcumatica())
                                     {
-                                        UpdateWeight(Properties.Settings.Default.ScaleID, ConvertWeightToKilogram(currentWeight, weightUnit));
-                                        _lastWeightSentToAcumatica = currentWeight;
+                                        UpdateWeight(Properties.Settings.Default.ScaleID, ConvertWeightToKilogram(readWeight, weightUnit));
+                                        _lastWeightSentToAcumatica = readWeight;
                                     }
                                 }
                             }


### PR DESCRIPTION
Miscellaneous bug fixes

1. Swallow exception on Acumatica session logout in configuration test.

2. Add a 'Show all devices' checkbox in scale configuration for scales that don't declare ScaleData report capabilities.

3. Exclude ScaleData readings for scales that respond with a HID report success message to ScaleData polling despite returning an empty message by ignoring messages containing WeightMode = 0.

4. Extend ScanLog Time column width.

5. Added a 'using' directive that I forgot for reading HID vendor/product list.