### PR TITLE
Shoebacca feedback

### DIFF
--- a/Customization/Pages/SO/SO302010.aspx
+++ b/Customization/Pages/SO/SO302010.aspx
@@ -7,8 +7,8 @@
 	    function Barcode_Initialize(ctrl) {
 			ctrl.element.addEventListener('keydown', function(e) {
 	            if (e.keyCode === 13) { //Enter key 
-	                e.preventDefault();
-				    e.stopPropagation();
+                    e.preventDefault();
+                    e.stopPropagation();
 	                var ds = px_alls["ds"];
 	                ds.executeCallback("scan");
 				}
@@ -58,8 +58,8 @@
 
 	<px:PXDataSource ID="ds" runat="server" Visible="True" Width="100%" TypeName="PX.Objects.SO.PickPackShip" PrimaryView="Document">
 		<CallbackCommands>
-			<px:PXDSCallbackCommand Name="Confirm" Visible="True" CommitChanges="True" />
-			<px:PXDSCallbackCommand Name="ConfirmAll" Visible="True" CommitChanges="True" />
+			<px:PXDSCallbackCommand Name="Confirm" Visible="False" CommitChanges="True" />
+			<px:PXDSCallbackCommand Name="ConfirmAll" Visible="False" CommitChanges="True" />
             <px:PXDSCallbackCommand Name="Scan" Visible="False" CommitChanges="True" />
             <px:PXDSCallbackCommand Name="Allocations" Visible="False" CommitChanges="true" DependOnGrid="grid" />
 		</CallbackCommands>

--- a/Customization/Pages/SO/SO302010.aspx
+++ b/Customization/Pages/SO/SO302010.aspx
@@ -4,11 +4,15 @@
 <%@ MasterType VirtualPath="~/MasterPages/FormDetail.master" %>
 <asp:content id="cont1" contentplaceholderid="phDS" runat="Server">
 	<script language="javascript" type="text/javascript">
-	    function Barcode_KeyDown(ctrl, e) {
-	        if (e.keyCode === 13) { //Enter key 
-	            var ds = px_alls["ds"];
-	            ds.executeCallback("scan");
-	        }
+	    function Barcode_Initialize(ctrl) {
+			ctrl.element.addEventListener('keydown', function(e) {
+	            if (e.keyCode === 13) { //Enter key 
+	                e.preventDefault();
+					e.stopPropagation();
+	                var ds = px_alls["ds"];
+	                ds.executeCallback("scan");
+				}
+	        });
 	    }
 
 	    function ActionCallback(callbackContext) {
@@ -19,22 +23,18 @@
 	            if (edStatus.getValue() == "OK") {
 	                var audio = new Audio(baseUrl + 'Sounds/success.wav');
 	                audio.play();
-	                px_alls["edShipmentNbr"].focus();
 	            }
 	            else if (edStatus.getValue() == "CLR") {
 	                var audio = new Audio(baseUrl + 'Sounds/balloon.wav');
 	                audio.play();
-	                px_alls["edShipmentNbr"].focus();
 	            }
 	            else if (edStatus.getValue() == "SCN" || edStatus.getValue() == "INF") {
 	                var audio = new Audio(baseUrl + 'Sounds/balloon.wav');
 	                audio.play();
-	                px_alls["edBarcode"].focus();
 	            }
 	            else if (edStatus.getValue() == "ERR") {
 	                var audio = new Audio(baseUrl + 'Sounds/asterisk.wav');
 	                audio.play();
-	                px_alls["edBarcode"].focus();
 	            }
 	        }
 	    };
@@ -69,14 +69,14 @@
 	<px:PXFormView ID="form" runat="server" DataSourceID="ds" Height="100px" Width="100%" Visible="true" DataMember="Document" DefaultControlID="edShipmentNbr">
         <Template>
             <px:PXLayoutRule runat="server" StartColumn="True" LabelsWidth="S" ControlSize="L" />
-			<px:PXSelector ID="edShipmentNbr" runat="server" DataField="ShipmentNbr" AutoRefresh="true" AllowEdit="true" CommitChanges="true" AutoComplete="false" />
             <px:PXTextEdit ID="edBarcode" runat="server" DataField="Barcode">
-                <ClientEvents KeyDown="Barcode_KeyDown" />
-            </px:PXTextEdit>
+                <ClientEvents Initialize="Barcode_Initialize" />
+            </px:PXTextEdit>            
+			<px:PXSelector ID="edShipmentNbr" runat="server" DataField="ShipmentNbr" AutoRefresh="true" AllowEdit="true" CommitChanges="true" AutoComplete="false" />
             <px:PXCheckBox ID="edLotSerialSearch" runat="server" DataField="LotSerialSearch" />
             <px:PXLayoutRule runat="server" StartColumn="True" LabelsWidth="S" ControlSize="L" ColumnWidth="M" />
             <px:PXLayoutRule runat="server" ColumnSpan="2" />
-            <px:PXTextEdit ID="edMessage" runat="server" DataField="Message" Width="640px" Style="font-size: 12pt; font-weight: bold;" SuppressLabel="true" />
+            <px:PXTextEdit ID="edMessage" runat="server" DataField="Message" Width="640px" Style="font-size: 10pt; font-weight: bold;" SuppressLabel="true" />
             <px:PXNumberEdit ID="edQuantity" runat="server" DataField="Quantity" />
             <px:PXLayoutRule runat="server" StartColumn="True" LabelsWidth="S" ControlSize="M" />
             <px:PXGroupBox ID="gbMode" runat="server" Caption="Scan Mode" DataField="ScanMode" RenderSimple="True" RenderStyle="Simple">

--- a/Customization/Pages/SO/SO302010.aspx
+++ b/Customization/Pages/SO/SO302010.aspx
@@ -8,7 +8,7 @@
 			ctrl.element.addEventListener('keydown', function(e) {
 	            if (e.keyCode === 13) { //Enter key 
 	                e.preventDefault();
-					e.stopPropagation();
+				    e.stopPropagation();
 	                var ds = px_alls["ds"];
 	                ds.executeCallback("scan");
 				}

--- a/Customization/_project/SOShipLine.xml
+++ b/Customization/_project/SOShipLine.xml
@@ -1,4 +1,4 @@
 ﻿<Table TableName="SOShipLine">
-    <Column TableName="SOShipLine" ColumnName="PackedQty" ColumnType="decimal" AllowNull="True" DefaultValue="0" MaxLength="25" DecimalPrecision="6" DecimalLength="25" IsNewColumn="True" IsUnicode="True" />
-    <Column TableName="SOShipLine" ColumnName="BasePackedQty" ColumnType="decimal" AllowNull="True" DefaultValue="0" MaxLength="25" DecimalPrecision="6" DecimalLength="25" IsNewColumn="True" IsUnicode="True" />
+    <Column TableName="SOShipLine" ColumnName="PackedQty" ColumnType="decimal" AllowNull="False" DefaultValue="0" MaxLength="25" DecimalPrecision="6" DecimalLength="25" IsNewColumn="True" IsUnicode="True" />
+    <Column TableName="SOShipLine" ColumnName="BasePackedQty" ColumnType="decimal" AllowNull="False" DefaultValue="0" MaxLength="25" DecimalPrecision="6" DecimalLength="25" IsNewColumn="True" IsUnicode="True" />
 </Table>

--- a/PX.Objects.WM/Descriptor/Messages.cs
+++ b/PX.Objects.WM/Descriptor/Messages.cs
@@ -96,7 +96,7 @@ namespace PX.Objects.WM
         public const string ShipmentLineMissing = "Line {0} not found in shipment.";
         public const string ShipmentMissing = "Shipment not found.";
         public const string ShipmentNbrMissing = "Shipment {0} not found.";
-        public const string ShipmentInvalid = "Shipment {0} is invalid for processing.";
+        public const string ShipmentInvalid = "Shipment {0} status is invalid for processing.";
         public const string ShipmentQuantityMismatchPrompt = "The quantity picked for one or more lines doesn't match with the shipment. Do you want to continue?";
         public const string ShipmentReady = "Shipment {0} loaded and ready to pick.";
         public const string ShipmentLineQuantityNotPacked = "One or more lines for item '{0}' have quantities that have not been packed.";

--- a/PX.Objects.WM/Descriptor/Messages.cs
+++ b/PX.Objects.WM/Descriptor/Messages.cs
@@ -96,6 +96,7 @@ namespace PX.Objects.WM
         public const string ShipmentLineMissing = "Line {0} not found in shipment.";
         public const string ShipmentMissing = "Shipment not found.";
         public const string ShipmentNbrMissing = "Shipment {0} not found.";
+        public const string ShipmentInvalid = "Shipment {0} is invalid for processing.";
         public const string ShipmentQuantityMismatchPrompt = "The quantity picked for one or more lines doesn't match with the shipment. Do you want to continue?";
         public const string ShipmentReady = "Shipment {0} loaded and ready to pick.";
         public const string ShipmentLineQuantityNotPacked = "One or more lines for item '{0}' have quantities that have not been packed.";


### PR DESCRIPTION
Modifications based on Shoebacca feedback: … 
1. Error beep when weight can't be calculated automatically
2. Rename Barcode field the "Scan" field, make shipment number and quantity read-only and invert in UI - will solve focus issues. See if we can use
e.preventDefault(); instead of forcing focus. NOTE: test with lot-serial feature OFF, this is how I found problem behaviour.
3. Behaviour when shipment on hold (red X) or already confirmed is entered from barcode field -- still loads shipment lines, and it should not. Ideally should tell you that shipment status is invalid for processing (instead of shipment not found), and DEFINITELY system shouldn't load the lines of this shipment!!!
4. Make Scan Message smaller -- doesn't look nice in most case